### PR TITLE
update node version and update files glob to only include js/ts files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     default: "false"
     required: false
 runs:
-  using: "node12"
+  using: "node16"
   main: "lib/index.js"
 branding:
   icon: "check-circle"

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
   files:
     description: "Glob pattern of files to be linted."
-    default: "**/*"
+    default: "**/*{.js,.jsx,.ts,.tsx}"
     required: false
   ignore:
     description: "Glob pattern to ignore from linting."


### PR DESCRIPTION
Updated the node version from v12 to v16.
Also updated the `files` glob pattern to include the extensions. It appears that the `files` glob pattern overrides the `extensions` provided, as shown when running the following:
```
$ npx eslint "**/*" --ext .ts

/Users/gurs1kh/git/nutrisense/nutrisense-eslint-action/LICENSE.md
  2:4  error  Parsing error: ';' expected

/Users/gurs1kh/git/nutrisense/nutrisense-eslint-action/README.md
  1:1  error  Parsing error: Invalid character

/Users/gurs1kh/git/nutrisense/nutrisense-eslint-action/__tests__/fixtures/getCommit.ts
...
```
Anyways, this change is needed so that `eslint` doesn't annotate `.txt` files with perceived errors.